### PR TITLE
feature: allow any value to be saved against a mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,28 @@ Reaction::has($post, $user, 'heart'); // returns whether the user has reacted wi
 Reaction::count($post, 'person_raising_hand'); // returns the amount of 'person_raising_hand' reactions for the given post
 ```
 
+You can also use wildcards to allow any value for a specific mark.
+
+Here's an example when working with reactions:
+
+``` php
+'allowed_values' => [
+    'reaction' => '*',
+],
+```
+
+When set, you can use any value when giving a reaction:
+
+``` php
+use App\Models\Post;
+use Maize\Markable\Models\Reaction;
+
+$post = Post::firstOrFail();
+$user = auth()->user();
+
+Reaction::add($post, $user, 'random_value'); // adds the 'random_value' reaction to the post for the given user
+```
+
 ### Retrieve the list of marks of an entity with eloquent
 
 ``` php

--- a/config/markable.php
+++ b/config/markable.php
@@ -39,5 +39,6 @@ return [
 
     'allowed_values' => [
         'reaction' => [],
+        'favorite' => '*',
     ],
 ];

--- a/config/markable.php
+++ b/config/markable.php
@@ -39,6 +39,5 @@ return [
 
     'allowed_values' => [
         'reaction' => [],
-        'favorite' => '*',
     ],
 ];

--- a/src/Mark.php
+++ b/src/Mark.php
@@ -24,7 +24,7 @@ abstract class Mark extends MorphPivot
         )->plural()->lower()->__toString();
     }
 
-    public static function allowedValues(): mixed
+    public static function allowedValues(): array|string|null
     {
         $className = Str::lower(static::getMarkClassName());
 
@@ -100,8 +100,13 @@ abstract class Mark extends MorphPivot
 
     public static function hasAllowedValues(?string $value): bool
     {
-        $allowedValues = static::allowedValues();
-        return ($allowedValues === '*' || in_array($value, $allowedValues ?? [null]));
+        $allowedValues = static::allowedValues() ?? [null];
+
+        if ($allowedValues === '*') {
+            return true;
+        }
+
+        return in_array($value, $allowedValues);
     }
 
     public function user(): BelongsTo

--- a/src/Mark.php
+++ b/src/Mark.php
@@ -24,7 +24,7 @@ abstract class Mark extends MorphPivot
         )->plural()->lower()->__toString();
     }
 
-    public static function allowedValues(): ?array
+    public static function allowedValues(): mixed
     {
         $className = Str::lower(static::getMarkClassName());
 
@@ -100,7 +100,8 @@ abstract class Mark extends MorphPivot
 
     public static function hasAllowedValues(?string $value): bool
     {
-        return in_array($value, static::allowedValues() ?? [null]);
+        $allowedValues = static::allowedValues();
+        return ($allowedValues === '*' || in_array($value, $allowedValues ?? [null]));
     }
 
     public function user(): BelongsTo

--- a/tests/ReactionTest.php
+++ b/tests/ReactionTest.php
@@ -30,6 +30,25 @@ class ReactionTest extends TestCase
     }
 
     /** @test */
+    public function can_add_any_value_with_wildcard()
+    {
+        config()->set('markable.allowed_values.reaction', '*');
+
+        $article = Article::factory()->create();
+        $user = User::factory()->create();
+        $table = (new Reaction)->getTable();
+
+        Reaction::add($article, $user, 'random_value');
+        $this->assertDatabaseCount($table, 1);
+        $this->assertDatabaseHas($table, [
+            'user_id' => $user->getKey(),
+            'markable_id' => $article->getKey(),
+            'markable_type' => $article->getMorphClass(),
+            'value' => 'random_value',
+        ]);
+    }
+
+    /** @test */
     public function can_add_a_reaction()
     {
         $article = Article::factory()->create();


### PR DESCRIPTION
When using a mark as a favourite or bookmark the user might want to use a custom value not in a defined list, this allows any value to be saved