### PR TITLE
bump spatie/laravel-package-tools to 1.92.6 due to bug fix in PR #174

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": "^8.0",
         "illuminate/database": "^9.0|^10.0|^11.0|^12.0",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
-        "spatie/laravel-package-tools": "^1.14.1"
+        "spatie/laravel-package-tools": "^1.92.6"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
The spatie/laravel-package-tools had an issue that was fixed in https://github.com/spatie/laravel-package-tools/pull/174.